### PR TITLE
Feature/2 PlayerPrefs を用いて対局の保存を実現する

### DIFF
--- a/Assets/Scenes/Choose.unity
+++ b/Assets/Scenes/Choose.unity
@@ -604,6 +604,83 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 435051977}
   m_CullTransparentMesh: 0
+--- !u!1 &576242954
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 576242955}
+  - component: {fileID: 576242957}
+  - component: {fileID: 576242956}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &576242955
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576242954}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1327011445}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &576242956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576242954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u3044\u3044\u3048"
+--- !u!222 &576242957
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576242954}
+  m_CullTransparentMesh: 0
 --- !u!1 &685783783
 GameObject:
   m_ObjectHideFlags: 0
@@ -676,6 +753,135 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 685783783}
+  m_CullTransparentMesh: 0
+--- !u!1 &693965670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 693965671}
+  - component: {fileID: 693965674}
+  - component: {fileID: 693965673}
+  - component: {fileID: 693965672}
+  m_Layer: 5
+  m_Name: YesButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &693965671
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693965670}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1782566821}
+  m_Father: {fileID: 1699716061}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -65, y: -40}
+  m_SizeDelta: {x: 140, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &693965672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693965670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 693965673}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1947928535}
+        m_MethodName: OnPlaySavedGameYesButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &693965673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693965670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &693965674
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 693965670}
   m_CullTransparentMesh: 0
 --- !u!1 &795797588
 GameObject:
@@ -1814,6 +2020,105 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1161033094}
   m_CullTransparentMesh: 0
+--- !u!1 &1175464703
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1175464707}
+  - component: {fileID: 1175464706}
+  - component: {fileID: 1175464705}
+  - component: {fileID: 1175464704}
+  m_Layer: 5
+  m_Name: CheckPlaySavedGameCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1175464704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1175464703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1175464705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1175464703}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1175464706
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1175464703}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1175464707
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1175464703}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 1699716061}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1265432668
 GameObject:
   m_ObjectHideFlags: 0
@@ -1906,6 +2211,135 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1327011444
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1327011445}
+  - component: {fileID: 1327011448}
+  - component: {fileID: 1327011447}
+  - component: {fileID: 1327011446}
+  m_Layer: 5
+  m_Name: NoButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1327011445
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1327011444}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 576242955}
+  m_Father: {fileID: 1699716061}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 75, y: -40}
+  m_SizeDelta: {x: 140, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1327011446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1327011444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1327011447}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1947928535}
+        m_MethodName: OnPlaySavedGameNoButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: -1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1327011447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1327011444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1327011448
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1327011444}
+  m_CullTransparentMesh: 0
 --- !u!1 &1435568518
 GameObject:
   m_ObjectHideFlags: 0
@@ -2412,6 +2846,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1675688379}
   m_CullTransparentMesh: 0
+--- !u!1 &1699716060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1699716061}
+  - component: {fileID: 1699716063}
+  - component: {fileID: 1699716062}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1699716061
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699716060}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 1}
+  m_Children:
+  - {fileID: 1789401965}
+  - {fileID: 693965671}
+  - {fileID: 1327011445}
+  m_Father: {fileID: 1175464707}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1699716062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699716060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1699716063
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1699716060}
+  m_CullTransparentMesh: 0
 --- !u!1 &1703827995
 GameObject:
   m_ObjectHideFlags: 0
@@ -2488,6 +2998,160 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1703827995}
+  m_CullTransparentMesh: 0
+--- !u!1 &1782566820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1782566821}
+  - component: {fileID: 1782566823}
+  - component: {fileID: 1782566822}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1782566821
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1782566820}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 693965671}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1782566822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1782566820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u306F\u3044"
+--- !u!222 &1782566823
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1782566820}
+  m_CullTransparentMesh: 0
+--- !u!1 &1789401964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1789401965}
+  - component: {fileID: 1789401967}
+  - component: {fileID: 1789401966}
+  m_Layer: 5
+  m_Name: SaveConfirmText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1789401965
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789401964}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1699716061}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1789401966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789401964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: ff2a9749a02e3dc42b2513758212c86a, type: 3}
+    m_FontSize: 50
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: "\u524D\u56DE\u306E\u5BFE\u5C40\u304B\u3089\u59CB\u3081\u307E\u3059\u304B\uFF1F"
+--- !u!222 &1789401967
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1789401964}
   m_CullTransparentMesh: 0
 --- !u!1 &1823429761
 GameObject:
@@ -2974,8 +3638,9 @@ MonoBehaviour:
   - {fileID: 890207917}
   - {fileID: 804767827}
   dropDown: {fileID: 40490985}
-  MainPanel: {fileID: 1703827995}
-  SettingPanel: {fileID: 1675688379}
+  mainPanel: {fileID: 1703827995}
+  settingPanel: {fileID: 1675688379}
+  checkPlaySavedGameCanvas: {fileID: 1175464703}
 --- !u!1 &1998084061
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PvP553.unity
+++ b/Assets/Scenes/PvP553.unity
@@ -472,6 +472,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 339380768}
   m_CullTransparentMesh: 0
+--- !u!1 &417793124
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 417793125}
+  - component: {fileID: 417793127}
+  - component: {fileID: 417793126}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &417793125
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417793124}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 1}
+  m_Children:
+  - {fileID: 1401274029}
+  - {fileID: 642428925}
+  - {fileID: 1962453193}
+  m_Father: {fileID: 1332822002}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -50, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &417793126
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417793124}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10911, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &417793127
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 417793124}
+  m_CullTransparentMesh: 0
 --- !u!1 &439495843
 GameObject:
   m_ObjectHideFlags: 0
@@ -561,12 +637,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b24cf3506629a0f428ccb062fc52955f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cancelgridChooseButton: {fileID: 0}
-  changeDimensionButton: {fileID: 1958739732}
-  gridChooseButton: {fileID: 0}
-  reverseButton: {fileID: 0}
-  nariYesButton: {fileID: 0}
-  nariNoButton: {fileID: 0}
+  saveConfirmCanvas: {fileID: 1332822001}
   game: {fileID: 1671133321}
 --- !u!4 &531612250
 Transform:
@@ -825,6 +896,83 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &613767310
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 613767311}
+  - component: {fileID: 613767313}
+  - component: {fileID: 613767312}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &613767311
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613767310}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1962453193}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &613767312
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613767310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u3044\u3044\u3048"
+--- !u!222 &613767313
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 613767310}
+  m_CullTransparentMesh: 0
 --- !u!1 &632788027
 GameObject:
   m_ObjectHideFlags: 0
@@ -944,6 +1092,212 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &641544523
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 641544524}
+  - component: {fileID: 641544526}
+  - component: {fileID: 641544525}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &641544524
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 641544523}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 642428925}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &641544525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 641544523}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 30
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: "\u306F\u3044"
+--- !u!222 &641544526
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 641544523}
+  m_CullTransparentMesh: 0
+--- !u!1 &642428924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 642428925}
+  - component: {fileID: 642428928}
+  - component: {fileID: 642428927}
+  - component: {fileID: 642428926}
+  m_Layer: 5
+  m_Name: YesButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &642428925
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642428924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 641544524}
+  m_Father: {fileID: 417793125}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -65, y: -40}
+  m_SizeDelta: {x: 140, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &642428926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642428924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 642428927}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 531612249}
+        m_MethodName: OnSaveYesButtonClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &642428927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642428924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &642428928
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 642428924}
+  m_CullTransparentMesh: 0
 --- !u!1 &642795545
 GameObject:
   m_ObjectHideFlags: 0
@@ -1270,7 +1624,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &855902005
 GameObject:
@@ -1793,7 +2147,7 @@ RectTransform:
   m_Children:
   - {fileID: 856445817}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1830,7 +2184,7 @@ Transform:
   - {fileID: 1414560349}
   - {fileID: 855902006}
   m_Father: {fileID: 0}
-  m_RootOrder: 15
+  m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1046414119
 GameObject:
@@ -1942,7 +2296,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 75, y: -40}
-  m_SizeDelta: {x: 140, y: 60}
+  m_SizeDelta: {x: 150, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1053855409
 MonoBehaviour:
@@ -2329,7 +2683,7 @@ GameObject:
   - component: {fileID: 1178988603}
   - component: {fileID: 1178988602}
   m_Layer: 5
-  m_Name: Button
+  m_Name: FinishButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2671,8 +3025,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -65, y: -40}
-  m_SizeDelta: {x: 140, y: 60}
+  m_AnchoredPosition: {x: -75, y: -40}
+  m_SizeDelta: {x: 150, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1327900897
 MonoBehaviour:
@@ -2764,6 +3118,105 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1327900895}
   m_CullTransparentMesh: 0
+--- !u!1 &1332821998
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1332822002}
+  - component: {fileID: 1332822001}
+  - component: {fileID: 1332822000}
+  - component: {fileID: 1332821999}
+  m_Layer: 5
+  m_Name: CheckSaveCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1332821999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332821998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1332822000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332821998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &1332822001
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332821998}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1332822002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1332821998}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 417793125}
+  m_Father: {fileID: 0}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1354680495
 GameObject:
   m_ObjectHideFlags: 0
@@ -2870,6 +3323,83 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1377425131}
+  m_CullTransparentMesh: 0
+--- !u!1 &1401274028
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1401274029}
+  - component: {fileID: 1401274031}
+  - component: {fileID: 1401274030}
+  m_Layer: 5
+  m_Name: SaveConfirmText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1401274029
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401274028}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 417793125}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 20}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1401274030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401274028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: ff2a9749a02e3dc42b2513758212c86a, type: 3}
+    m_FontSize: 50
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: "\u5BFE\u5C40\u3092\u4FDD\u5B58\u3057\u307E\u3059\u304B\uFF1F"
+--- !u!222 &1401274031
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1401274028}
   m_CullTransparentMesh: 0
 --- !u!1 &1414560348
 GameObject:
@@ -3333,7 +3863,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -80, y: 20}
+  m_AnchoredPosition: {x: 10, y: 20}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1933351424
@@ -3355,13 +3885,13 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_Font: {fileID: 12800000, guid: ff2a9749a02e3dc42b2513758212c86a, type: 3}
     m_FontSize: 50
     m_FontStyle: 0
     m_BestFit: 0
     m_MinSize: 0
     m_MaxSize: 100
-    m_Alignment: 0
+    m_Alignment: 1
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 1
@@ -3476,7 +4006,7 @@ GameObject:
   - component: {fileID: 1958739733}
   - component: {fileID: 1958739732}
   m_Layer: 5
-  m_Name: ChangedimButton
+  m_Name: MattaButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3592,6 +4122,135 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1958739730}
   m_CullTransparentMesh: 0
+--- !u!1 &1962453192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1962453193}
+  - component: {fileID: 1962453196}
+  - component: {fileID: 1962453195}
+  - component: {fileID: 1962453194}
+  m_Layer: 5
+  m_Name: NoButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1962453193
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1962453192}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 613767311}
+  m_Father: {fileID: 417793125}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 75, y: -40}
+  m_SizeDelta: {x: 140, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1962453194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1962453192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1962453195}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 531612249}
+        m_MethodName: OnSaveNoButtonClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: -1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1962453195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1962453192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1962453196
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1962453192}
+  m_CullTransparentMesh: 0
 --- !u!1 &2029574996
 GameObject:
   m_ObjectHideFlags: 0
@@ -3686,7 +4345,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 14
+  m_RootOrder: 13
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2091339314
 GameObject:

--- a/Assets/Scripts/Choose/InitialSetting.cs
+++ b/Assets/Scripts/Choose/InitialSetting.cs
@@ -12,12 +12,15 @@ namespace Choose
         public static int yLength = 3; //yが高さ
         public static int zLength = 5;
 
+        private int gameMode = 0; //0...CPU戦, 1...対人戦
+
         private int audioPlaying = 0;
         public GameObject[] audioSources = new GameObject[3];
         public GameObject dropDown;
 
-        public GameObject MainPanel;
-        public GameObject SettingPanel;
+        public GameObject mainPanel;
+        public GameObject settingPanel;
+        public GameObject checkPlaySavedGameCanvas;
 
         public void OnBGMChanged()
         {
@@ -28,19 +31,22 @@ namespace Choose
             Debug.Log("after: " + audioPlaying);
         }
 
-        public void OnSettingButtonClicked(){
-            this.SettingPanel.SetActive(true);
+        public void OnSettingButtonClicked()
+        {
+            this.settingPanel.SetActive(true);
         }
-        public void OnSettingFinishButtonClicked(){
-            this.SettingPanel.SetActive(false);
+        public void OnSettingFinishButtonClicked()
+        {
+            this.settingPanel.SetActive(false);
         }
 
-        public void ChoosePvP993()
+        public void ChooseCPU553()
         {
-            xLength = 9;
+            xLength = 5;
             yLength = 3;
-            zLength = 9;
-            SceneManager.LoadScene("PvP993");
+            zLength = 5;
+            gameMode = 0;
+            SceneManager.LoadScene("PvP553");
         }
 
         public void ChoosePvP553()
@@ -48,12 +54,30 @@ namespace Choose
             xLength = 5;
             yLength = 3;
             zLength = 5;
-            SceneManager.LoadScene("PvP553");
+            gameMode = 1;
+            if (PlayerPrefs.HasKey("savedGame")) checkPlaySavedGameCanvas.SetActive(true);
+            else SceneManager.LoadScene("PvP553");
+        }
+
+        public void OnPlaySavedGameYesButton()
+        {
+            PlayerPrefs.SetInt("playSavedGame", 0);
+            PlayerPrefs.Save();
+            string scene = (gameMode == 0) ? "PvP553" : "PvP553";
+            SceneManager.LoadScene(scene);
+        }
+        public void OnPlaySavedGameNoButton()
+        {
+            string scene = (gameMode == 0) ? "PvP553" : "PvP553";
+            SceneManager.LoadScene(scene);
         }
 
         public void Start()
         {
-            foreach(GameObject source in audioSources){
+            settingPanel.SetActive(false);
+            checkPlaySavedGameCanvas.SetActive(false);
+            foreach (GameObject source in audioSources)
+            {
                 source.transform.parent = null;
                 DontDestroyOnLoad(source);
             }

--- a/Assets/Scripts/MakeKomaPrefs/FuPrefab.cs
+++ b/Assets/Scripts/MakeKomaPrefs/FuPrefab.cs
@@ -15,13 +15,11 @@ namespace MakeKomaPrefs
         // Start is called before the first frame update
         void Awake()
         {
-            Debug.Log("start called");
             InitVars(Sunpou.Kind.Fu);
             var filter = GetComponent<MeshFilter>();
             filter.sharedMesh = mesh;
             var renderer = GetComponent<MeshRenderer>();
             renderer.material = _mat[0];
-            Debug.Log("start fin");
         }
 
         private void Update()

--- a/Assets/Scripts/MakeKomaPrefs/KomaPrefab.cs
+++ b/Assets/Scripts/MakeKomaPrefs/KomaPrefab.cs
@@ -20,7 +20,6 @@ namespace MakeKomaPrefs
         int komakind;
         protected void InitVars(Sunpou.Kind k)
         {
-            Debug.Log("Initvars called");
             komakind = (int)k;
             sunpou = new float[3];
             degs = new float[3];
@@ -101,7 +100,6 @@ namespace MakeKomaPrefs
             27, 29, 28,
         };
             mesh.RecalculateNormals();
-            Debug.Log("Initvars fin");
         }
 
         public void ChangeMat()

--- a/Assets/Scripts/PvP553/Board.cs
+++ b/Assets/Scripts/PvP553/Board.cs
@@ -152,7 +152,6 @@ namespace PvP553
                 g.transform.localScale = new Vector3(boardScale2D * xLength, 0.001f, boardScale2D * zLength);
                 g.layer = g.transform.parent.gameObject.layer;
             }
-            Debug.Log(ob2D[0, 0, 0].transform.position);
         }
 
         public void CreateFrame(GameObject[,] fx3D, GameObject[,] fz3D, GameObject[,] fx2D, GameObject[,] fz2D)
@@ -222,7 +221,6 @@ namespace PvP553
                     fz2D[y, x].SetActive(true);
                 }
             }
-            Debug.Log("2DFrame Created.");
         }
 
         public float BoardScale2D { set { boardScale2D = value; } }

--- a/Assets/Scripts/PvP553/Game.cs
+++ b/Assets/Scripts/PvP553/Game.cs
@@ -28,7 +28,8 @@ namespace PvP553
             Debug.Log(contents);
             foreach (string s in contents) Debug.Log(s);
             turn = Convert.ToInt32(contents[0]);
-            from = new Vector3Int(Convert.ToInt32(contents[1]) / 100, Convert.ToInt32(contents[1]) / 10 % 10, Convert.ToInt32(contents[1]) % 10);
+            if (contents[1][0] == '-') from = new Vector3Int(-1, -1, -1);
+            else from = new Vector3Int(Convert.ToInt32(contents[1]) / 100, Convert.ToInt32(contents[1]) / 10 % 10, Convert.ToInt32(contents[1]) % 10);
             to = new Vector3Int(Convert.ToInt32(contents[2]) / 100, Convert.ToInt32(contents[2]) / 10 % 10, Convert.ToInt32(contents[2]) % 10);
             fromState = (Koma.Kind)Enum.ToObject(typeof(Koma.Kind), Convert.ToInt32(contents[3]));
             toState = (Koma.Kind)Enum.ToObject(typeof(Koma.Kind), Convert.ToInt32(contents[4]));
@@ -223,18 +224,6 @@ namespace PvP553
                 PlayerPrefs.DeleteKey("playSavedGame");
                 LoadGame();
             }
-
-            ProcessGameFromOneRecord(
-                new Record
-                (
-                    1,
-                    new Vector3Int(0, 1, 1),
-                    Koma.Kind.Fu,
-                    new Vector3Int(0, 1, 2),
-                    Koma.Kind.To,
-                    Koma.Kind.Emp
-                )
-            );
         }
 
         // Update is called once per frame
@@ -243,14 +232,14 @@ namespace PvP553
 
         }
 
-        public async void ChooseGrid(int idx) //実際に手番が進むメソッド
+        public async void ChooseGrid(int idx) //実際に手番が進むメソッド.
         {
             if (!mouseDetectable) return;
             int pushz = idx % 10;
             int pushy = (idx / 10) % 10;
             int pushx = (idx / 100) % 10;
 
-            //選択マスが移動可能マス（赤丸の表示されているマス）の場合は駒を移動させる ここで実際に手番が進む
+            //選択マスが移動可能マス（赤丸の表示されているマス）の場合は駒を移動させる ここで実際に手番が進む Recordを使って進める形に書き換えたい
             if (movableGrid2D[pushx, pushy, pushz].activeSelf)
             {
                 Koma.Kind got = Koma.Kind.Emp; //取った駒

--- a/Assets/Scripts/PvP553/Game.cs
+++ b/Assets/Scripts/PvP553/Game.cs
@@ -21,6 +21,19 @@ namespace PvP553
             fromState = fs; toState = ts;
             get = g;
         }
+        public Record(string recordStr)
+        {
+            string[] contents = recordStr.Split(new char[] { '|' });
+            Debug.Log(recordStr);
+            Debug.Log(contents);
+            foreach (string s in contents) Debug.Log(s);
+            turn = Convert.ToInt32(contents[0]);
+            from = new Vector3Int(Convert.ToInt32(contents[1]) / 100, Convert.ToInt32(contents[1]) / 10 % 10, Convert.ToInt32(contents[1]) % 10);
+            to = new Vector3Int(Convert.ToInt32(contents[2]) / 100, Convert.ToInt32(contents[2]) / 10 % 10, Convert.ToInt32(contents[2]) % 10);
+            fromState = (Koma.Kind)Enum.ToObject(typeof(Koma.Kind), Convert.ToInt32(contents[3]));
+            toState = (Koma.Kind)Enum.ToObject(typeof(Koma.Kind), Convert.ToInt32(contents[4]));
+            get = (Koma.Kind)Enum.ToObject(typeof(Koma.Kind), Convert.ToInt32(contents[5]));
+        }
         public int Turn { get { return turn; } }
         public Vector3Int From { get { return from; } }
         public Vector3Int To { get { return to; } }
@@ -205,8 +218,23 @@ namespace PvP553
             }
 
             nariConfirmCanvas.SetActive(false);
-            Vector3Int temp = myOuPos;
-            Debug.Log(gridButton2D[0, 0, 0].transform.position);
+            if (PlayerPrefs.HasKey("playSavedGame"))
+            {
+                PlayerPrefs.DeleteKey("playSavedGame");
+                LoadGame();
+            }
+
+            ProcessGameFromOneRecord(
+                new Record
+                (
+                    1,
+                    new Vector3Int(0, 1, 1),
+                    Koma.Kind.Fu,
+                    new Vector3Int(0, 1, 2),
+                    Koma.Kind.To,
+                    Koma.Kind.Emp
+                )
+            );
         }
 
         // Update is called once per frame
@@ -215,9 +243,8 @@ namespace PvP553
 
         }
 
-        public async void ChooseGrid(int idx) //実際に手番が進むメソッド 作業のしやすさを考慮してUpdate()直下に配置
+        public async void ChooseGrid(int idx) //実際に手番が進むメソッド
         {
-            Debug.Log(idx + " choosed");
             if (!mouseDetectable) return;
             int pushz = idx % 10;
             int pushy = (idx / 10) % 10;
@@ -241,8 +268,6 @@ namespace PvP553
                 }
                 if (fromx == -1 || fromy == -1 || fromz == -1)
                 {
-                    //Debug.Log("Choosed from Mochigoma");
-
                     int choose = -1;
                     if (turn == 1) for (int i = 0; i < myMochigomaBox.Count; i++) { if (myMochigomaBox[i].activeSelf) choose = i; }
                     else for (int i = 0; i < opMochigomaBox.Count; i++) { if (opMochigomaBox[i].activeSelf) choose = i; }
@@ -426,113 +451,6 @@ namespace PvP553
             }
         }
 
-        public void ChangeDimension()
-        {
-            // is3D = !is3D;
-            // cameraMover.CameraMovable = !cameraMover.CameraMovable;
-            // for (int x = 0; x < xLength; x++)
-            // {
-            //     for (int y = 0; y < yLength; y++)
-            //     {
-            //         for (int z = 0; z < zLength; z++)
-            //         {
-            //             if (koma_on_board3D[x, y, z] != null) koma_on_board3D[x, y, z].gameObject.SetActive(!koma_on_board3D[x, y, z].gameObject.activeSelf);
-            //             if (koma_on_board2D[x, y, z] != null) koma_on_board2D[x, y, z].gameObject.SetActive(!koma_on_board2D[x, y, z].gameObject.activeSelf);
-            //         }
-            //     }
-            // }
-
-            // for (int y = 0; y < yLength; y++)
-            // {
-            //     for (int z = 0; z <= zLength; z++)
-            //     {
-            //         frameX3D[y, z].SetActive(!frameX3D[y, z].activeSelf);
-            //         frameX2D[y, z].SetActive(!frameX2D[y, z].activeSelf);
-            //     }
-            // }
-            // for (int y = 0; y < yLength; y++)
-            // {
-            //     for (int x = 0; x <= xLength; x++)
-            //     {
-            //         frameZ3D[y, x].SetActive(!frameZ3D[y, x].activeSelf);
-            //         frameZ2D[y, x].SetActive(!frameZ2D[y, x].activeSelf);
-            //     }
-            // }
-
-            // if (frameZ2D[0, 0].activeSelf) //2Dモードに切り替えた場合はカメラを固定
-            // {
-            //     float c = 4.5f;
-            //     prevCameraPos = cameraMover.MainCameraTransformPosition;
-            //     cameraMover.MainCamera2DSetting(new Vector3(c, 12, c), new Vector3(c, 0, c));
-            // }
-            // else cameraMover.MainCameraTransformPosition = prevCameraPos;
-
-            // //3Dと2DのorangeBox, greenBox, movableGridのactiveを（必要なら）入れ替える
-            // for (int x = 0; x < xLength; x++)
-            // {
-            //     for (int y = 0; y < yLength; y++)
-            //     {
-            //         for (int z = 0; z < zLength; z++)
-            //         {
-            //             bool active3D, active2D;
-            //             active3D = orangeBox3D[x, y, z].activeSelf;
-            //             active2D = orangeBox2D[x, y, z].activeSelf;
-            //             if (active3D & !active2D)
-            //             {
-            //                 orangeBox2D[x, y, z].SetActive(true);
-            //                 orangeBox3D[x, y, z].SetActive(false);
-            //             }
-            //             else if (!active3D & active2D)
-            //             {
-            //                 orangeBox2D[x, y, z].SetActive(false);
-            //                 orangeBox3D[x, y, z].SetActive(true);
-            //             }
-
-            //             active3D = greenBox3D[x, y, z].activeSelf;
-            //             active2D = greenBox2D[x, y, z].activeSelf;
-            //             if (active3D & !active2D)
-            //             {
-            //                 greenBox2D[x, y, z].SetActive(true);
-            //                 greenBox3D[x, y, z].SetActive(false);
-            //             }
-            //             else if (!active3D & active2D)
-            //             {
-            //                 greenBox2D[x, y, z].SetActive(false);
-            //                 greenBox3D[x, y, z].SetActive(true);
-            //             }
-
-            //             active3D = movableGrid3D[x, y, z].activeSelf;
-            //             active2D = movableGrid2D[x, y, z].activeSelf;
-            //             if (active3D & !active2D)
-            //             {
-            //                 movableGrid2D[x, y, z].SetActive(true);
-            //                 movableGrid3D[x, y, z].SetActive(false);
-            //             }
-            //             else if (!active3D & active2D)
-            //             {
-            //                 movableGrid2D[x, y, z].SetActive(false);
-            //                 movableGrid3D[x, y, z].SetActive(true);
-            //             }
-
-
-            //         }
-            //     }
-            // }
-
-            // //gridButton の enabled を入れ替える
-            // for (int x = 0; x < xLength; x++)
-            // {
-            //     for (int y = 0; y < yLength; y++)
-            //     {
-            //         for (int z = 0; z < zLength; z++)
-            //         {
-            //             gridButton2D[x, y, z].enabled = !gridButton2D[x, y, z].enabled;
-            //         }
-            //     }
-            // }
-
-        }
-
         private void ChangeTurn() //手番を終えたプレイヤーの持ち駒を選択できなくする 
         {
             if (turn == 1)
@@ -711,7 +629,7 @@ namespace PvP553
             komainst.transform.GetChild(0).transform.GetChild(2).gameObject.SetActive(true);
         }
 
-        //持ち駒を生成して整列するメソッド
+        //持ち駒を生成して整列するメソッド. aimturn の人が駒を取った場合の挙動
         private void MochigomaGenerate(Koma.Kind k, int aimturn = 0)
         {
             int kind = (int)k;
@@ -773,7 +691,6 @@ namespace PvP553
                 {
                     for (int i = myMochigomaIdx.Count - 2; i >= ins; i--)
                     {
-                        Debug.Log(i);
                         //Vector3 pos = myMochigomaInstance[i + 1].transform.localPosition; //例えば銀がi, 桂馬がi+1のとき: まずは桂馬の位置を記録
                         MakeKomaPrefs.KomaPrefab2D inst = myMochigomaInstance[i + 1]; //桂馬のインスタンスも記憶
                         int idx = myMochigomaIdx[i + 1];
@@ -857,7 +774,7 @@ namespace PvP553
             MochigomaRelocate();
         }
 
-        private void MochigomaRelocate() //画面右端を超えないように持ち駒の位置調整
+        private void MochigomaRelocate() //持ち駒の画面上の位置を現在の持ち駒のリストから決定する
         {
             float newScale = 1.0f;
             //if (opMochigomaInstance.Count >= 20) newScale /= opMochigomaInstance.Count;
@@ -1173,7 +1090,6 @@ namespace PvP553
                                 {
                                     for (int z = 0; z < zLength; z++)
                                     {
-                                        Debug.Log(loc);
                                         if (work[x, y, z] > 0 && CheckMovable_Specific(work, work[x, y, z], -turn, new Vector3Int(x, y, z), loc))
                                         {
                                             int temp = work[loc.x, loc.y, loc.z];
@@ -1288,7 +1204,6 @@ namespace PvP553
                             MochigomaRemove(i, op.Turn);
                             koma.PutKoma(-op.Turn, (Koma.Kind)Math.Abs(search), op.To.x, op.To.y, op.To.z);
                             if (op.Get >= Koma.Kind.To) koma.Nari(koma_on_board3D[op.To.x, op.To.y, op.To.z], koma_on_board2D[op.To.x, op.To.y, op.To.z]);
-                            Debug.Log("Nari fin");
                             break;
                         }
                     }
@@ -1305,12 +1220,127 @@ namespace PvP553
         public void Matta()
         {
             if (record.Count > 0) Rewind();
-            //if (record.Count > 0) Rewind();
         }
 
-        public void ReverseView()
+        // Record のフィールドたち
+        // int turn; -> 1 or -1
+        // Vector3Int from, to; 
+        // Koma.Kind fromState, toState;
+        // Koma.Kind get;
+
+        private List<Record> str2record(string str)
         {
-            //cameraMover.transform.eulerAngles += new Vector3(0, 180, 0);
+            List<Record> ret = new List<Record>();
+            string[] recordStrArr = str.Split(new char[] { ',' });
+            foreach (string recordStr in recordStrArr)
+            {
+                if (recordStr.Length == 0) continue;
+                Record nowrecord = new Record(recordStr);
+                ret.Add(nowrecord);
+            }
+            return ret;
+        }
+        private string record2str()
+        {
+            string ret = "";
+            foreach (Record rec in record)
+            {
+                ret += rec.Turn.ToString();
+                ret += '|';
+                ret += rec.From.x.ToString();
+                ret += rec.From.y.ToString();
+                ret += rec.From.z.ToString();
+                ret += '|';
+                ret += rec.To.x.ToString();
+                ret += rec.To.y.ToString();
+                ret += rec.To.z.ToString();
+                ret += '|';
+                ret += ((int)rec.FromState).ToString();
+                ret += '|';
+                ret += ((int)rec.ToState).ToString();
+                ret += '|';
+                ret += ((int)rec.Get).ToString();
+                ret += ',';
+            }
+            return ret;
+        }
+        private void LoadGame()
+        {
+            string data = PlayerPrefs.GetString("savedGame");
+            record = str2record(data);
+            foreach (Record rec in record)
+            {
+                ProcessGameFromOneRecord(rec);
+            }
+        }
+        public void SaveGame()
+        {
+            string data = record2str();
+            PlayerPrefs.SetString("savedGame", data);
+            PlayerPrefs.Save();
+        }
+
+        private void ProcessGameFromOneRecord(Record rec)
+        {
+            //常に変わるもの: turn, boardState, koma_on_board3D/2D
+            //たまに変わるもの: 持ち駒関連, my/opOuPos
+            boardstate[rec.To.x, rec.To.y, rec.To.z] = (int)rec.ToState * rec.Turn;
+            if (rec.From.x == -1)
+            {
+                koma.PutKoma(rec.Turn, rec.ToState, rec.To.x, rec.To.y, rec.To.z);
+                if (rec.Turn == 1)
+                {
+                    for (int choose = 0; choose < myMochigomaInstance.Count; choose++)
+                    {
+                        if (myMochigomaIdx[choose] == (int)rec.ToState)
+                        {
+                            MochigomaRemove(choose, rec.Turn);
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    for (int choose = 0; choose < opMochigomaInstance.Count; choose++)
+                    {
+                        if (opMochigomaIdx[choose] == (int)rec.ToState)
+                        {
+                            MochigomaRemove(choose, rec.Turn);
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                boardstate[rec.From.x, rec.From.y, rec.From.z] = 0;
+                if (rec.Get != Koma.Kind.Emp)
+                {
+                    Destroy(koma_on_board3D[rec.To.x, rec.To.y, rec.To.z].gameObject);
+                    Destroy(koma_on_board2D[rec.To.x, rec.To.y, rec.To.z].gameObject);
+                    koma_on_board3D[rec.To.x, rec.To.y, rec.To.z] = null;
+                    koma_on_board2D[rec.To.x, rec.To.y, rec.To.z] = null;
+                    MochigomaGenerate(rec.Get, rec.Turn);
+                }
+                int dx = rec.To.x - rec.From.x;
+                int dy = rec.To.y - rec.From.y;
+                int dz = rec.To.z - rec.From.z;
+                koma_on_board3D[rec.From.x, rec.From.y, rec.From.z].transform.localPosition += new Vector3(dx, dy, dz);
+                koma_on_board2D[rec.From.x, rec.From.y, rec.From.z].transform.localPosition += new Vector3(dx, 0, dz + dy * (zLength + 1));
+                koma_on_board3D[rec.To.x, rec.To.y, rec.To.z] = koma_on_board3D[rec.From.x, rec.From.y, rec.From.z];
+                koma_on_board2D[rec.To.x, rec.To.y, rec.To.z] = koma_on_board2D[rec.From.x, rec.From.y, rec.From.z];
+                koma_on_board3D[rec.From.x, rec.From.y, rec.From.z] = null;
+                koma_on_board2D[rec.From.x, rec.From.y, rec.From.z] = null;
+
+                if (rec.FromState != rec.ToState) koma.Nari(koma_on_board3D[rec.To.x, rec.To.y, rec.To.z], koma_on_board2D[rec.To.x, rec.To.y, rec.To.z]);
+                if (rec.ToState == Koma.Kind.Ou || rec.ToState == Koma.Kind.Gyo)
+                {
+                    if (rec.Turn == 1) myOuPos = new Vector3Int(rec.To.x, rec.To.y, rec.To.z);
+                    else opOuPos = new Vector3Int(rec.To.x, rec.To.y, rec.To.z);
+                }
+            }
+            CalcReachableRange();
+            ChangeTurn();
         }
 
         public void UnActivateChoosingGrid()
@@ -1321,8 +1351,6 @@ namespace PvP553
                 {
                     for (int z = 0; z < zLength; z++)
                     {
-                        //greenBox3D[x, y, z].SetActive(false);
-                        //greenBox2D[x, y, z].SetActive(false);
                         movableGrid3D[x, y, z].SetActive(false);
                         movableGrid2D[x, y, z].SetActive(false);
                         orangeBox3D[x, y, z].SetActive(false);

--- a/Assets/Scripts/PvP553/Game.cs
+++ b/Assets/Scripts/PvP553/Game.cs
@@ -24,8 +24,6 @@ namespace PvP553
         public Record(string recordStr)
         {
             string[] contents = recordStr.Split(new char[] { '|' });
-            Debug.Log(recordStr);
-            Debug.Log(contents);
             foreach (string s in contents) Debug.Log(s);
             turn = Convert.ToInt32(contents[0]);
             if (contents[1][0] == '-') from = new Vector3Int(-1, -1, -1);
@@ -1281,9 +1279,10 @@ namespace PvP553
                 {
                     for (int choose = 0; choose < myMochigomaInstance.Count; choose++)
                     {
-                        if (myMochigomaIdx[choose] == (int)rec.ToState)
+                        if (myMochigomaIdx[choose] == (int)rec.ToState * rec.Turn)
                         {
                             MochigomaRemove(choose, rec.Turn);
+                            Debug.Log("持ち駒置いたよ");
                             break;
                         }
                     }
@@ -1292,9 +1291,10 @@ namespace PvP553
                 {
                     for (int choose = 0; choose < opMochigomaInstance.Count; choose++)
                     {
-                        if (opMochigomaIdx[choose] == (int)rec.ToState)
+                        if (opMochigomaIdx[choose] == (int)rec.ToState * rec.Turn)
                         {
                             MochigomaRemove(choose, rec.Turn);
+                            Debug.Log("持ち駒置いたよ");
                             break;
                         }
                     }

--- a/Assets/Scripts/PvP553/Game.cs
+++ b/Assets/Scripts/PvP553/Game.cs
@@ -1259,6 +1259,12 @@ namespace PvP553
             {
                 ProcessGameFromOneRecord(rec);
             }
+            if (record.Count != 0)
+            {
+                Record last = record[record.Count - 1];
+                greenBox3D[last.To.x, last.To.y, last.To.z].SetActive(true);
+                greenBox2D[last.To.x, last.To.y, last.To.z].SetActive(true);
+            }
         }
         public void SaveGame()
         {

--- a/Assets/Scripts/PvP553/Koma.cs
+++ b/Assets/Scripts/PvP553/Koma.cs
@@ -273,7 +273,6 @@ namespace PvP553
 
         public void PutKoma(int o, Kind kind, int x, int y, int z) //owner, 駒の種類, x, y, z, 拡大縮小
         {
-            Debug.Log("PutKoma called");
             int k = (int)kind; //kindにあたる駒のpiecesにおける添え字番号を計算
             koma3D[x, y, z] = Instantiate(pieces[k], pieces3DTransform);
             koma3D[x, y, z].gameObject.layer = koma3D[x, y, z].transform.parent.gameObject.layer;
@@ -288,7 +287,6 @@ namespace PvP553
             koma2D[x, y, z].gameObject.SetLayerRecursively(10);
 
             boardstate[x, y, z] = (int)kind * o;
-            Debug.Log("PutKoma fin");
         }
 
         public int Nari(MakeKomaPrefs.KomaPrefab koma3D, MakeKomaPrefs.KomaPrefab2D koma2D)
@@ -298,7 +296,6 @@ namespace PvP553
 
             //return komaName_to_kind[nari[kind]]; //正値を返すので手番に応じて呼び出し元で-1倍してね
             int ret = koma2D.Komakind + diff_nari > Enum.GetValues(typeof(Kind)).Length + 1 ? koma2D.Komakind : koma2D.Komakind + diff_nari;
-            Debug.Log("ret: " + ret);
             return koma2D.Komakind + diff_nari > Enum.GetValues(typeof(Kind)).Length + 1 ? koma2D.Komakind : koma2D.Komakind + diff_nari;
         }
 

--- a/Assets/Scripts/PvP553/MouseDetector.cs
+++ b/Assets/Scripts/PvP553/MouseDetector.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 
@@ -12,27 +13,18 @@ namespace PvP553
         private int yLength = Choose.InitialSetting.yLength;
         private int zLength = Choose.InitialSetting.zLength;
 
-        public Button cancelgridChooseButton;
-        public Button changeDimensionButton;
-        public Button gridChooseButton;
-        public Button reverseButton; //180°視点を反転
-        public Button nariYesButton, nariNoButton;
+        public Canvas saveConfirmCanvas;
         public Game game;
         // Start is called before the first frame update
         void Start()
         {
-
+            saveConfirmCanvas.gameObject.SetActive(false);
         }
 
         // Update is called once per frame
         void Update()
         {
-            /*
-            if (game.MouseDetectable)
-            {
-                if (Input.GetMouseButtonUp(0)) Debug.Log("yeah");
-            }
-            */
+
         }
 
         public void OnCancelGridChooseButtonClick()
@@ -46,19 +38,28 @@ namespace PvP553
             Koma.Nariflg = n;
         }
 
-        public void OnReverseButtonClick()
-        {
-            game.ReverseView();
-        }
-
         public void OnMattaButtonClick()
         {
-            game.Matta();
+            if (game.MouseDetectable) game.Matta();
         }
         public void OnFinishButtonClick()
         {
             //セーブしてシーン遷移
-            Debug.Log("FinishButton Clicked");
+            if (game.MouseDetectable)
+            {
+                game.MouseDetectable = false;
+                saveConfirmCanvas.gameObject.SetActive(true);
+                Debug.Log("FinishButton Clicked");
+            }
+        }
+        public void OnSaveYesButtonClick()
+        {
+            game.SaveGame();
+            SceneManager.LoadScene("choose");
+        }
+        public void OnSaveNoButtonClick()
+        {
+            SceneManager.LoadScene("choose");
         }
     }
 }


### PR DESCRIPTION
# 概要
PlayerPrefs を用いて途中で対局を終わらせる際に保存できるようにした
# 実装
- 終了ボタンを押すことで現在の対局を保存するか聞くようにした
- Game.cs 内に定義した Record クラスのオブジェクトをもとに手番を進めるメソッド ProcessGameFromOneRecord を作成した
- PlayerPrefs の仕様上 string と Record の相互変換が必要だが、手番の区切りは ',' で各フィールドの区切りは '|' とした。
# テスト
持ち駒がともに複数ある状態まで対局を進め、そこで保存して対局に復帰。その後保存した対局が復元され、待ったにより初期状態まで戻れることを確認した

![save1](https://user-images.githubusercontent.com/45731368/134849531-60c98cbd-8e03-426d-b20d-1746cedb4d0a.PNG)
![save2](https://user-images.githubusercontent.com/45731368/134849548-2dc38654-7005-4051-b636-4237ec32f834.PNG)
![save3](https://user-images.githubusercontent.com/45731368/134849559-c720d434-67eb-47d4-8991-b25a64e11aa3.PNG)
![save4](https://user-images.githubusercontent.com/45731368/134849566-cdc9146a-c21a-46e1-a614-ca91bb84bbd0.PNG)

# 備考
復帰後も最新の手を緑で光らせた方が良いかも

